### PR TITLE
fix: prevent default aws profile being overwritten during rotation

### DIFF
--- a/src/cmd/revoke-certificate.go
+++ b/src/cmd/revoke-certificate.go
@@ -16,13 +16,17 @@ var revokeCertificateCmd = &cobra.Command{
 	Short: "Revoke a certificate in AWS PCA",
 	Long:  `Allow to revoke and provided a reason as to why a certificate is revoked in AWS PCA`,
 	Run: func(cmd *cobra.Command, args []string) {
-		profileName, _ := cmd.Flags().GetString(flags.ProfileName)
+		profileNameAcm, _ := cmd.Flags().GetString(flags.ProfileNameAcm)
+		profileNameAcmPca, _ := cmd.Flags().GetString(flags.ProfileNameAcmPca)
 		certArn, _ := cmd.Flags().GetString(flags.CertificateArn)
 		pcaArn, _ := cmd.Flags().GetString(flags.AcmpcaArn)
 		revocationReason, _ := cmd.Flags().GetString(flags.RevocationReason)
-		region, _ := cmd.Flags().GetString(flags.PcaRegion)
-		accessKey, _ := cmd.Flags().GetString(flags.AccessKeyAcmPca)
-		secretAccessKey, _ := cmd.Flags().GetString(flags.SecretAccessKeyAcmPca)
+		acmRegion, _ := cmd.Flags().GetString(flags.AcmRegion)
+		pcaRegion, _ := cmd.Flags().GetString(flags.PcaRegion)
+		acmAccessKey, _ := cmd.Flags().GetString(flags.AccessKeyAcm)
+		acmPcaAccessKey, _ := cmd.Flags().GetString(flags.AccessKeyAcmPca)
+		acmSecretAccessKey, _ := cmd.Flags().GetString(flags.SecretAccessKeyAcm)
+		acmPcaSecretAccessKey, _ := cmd.Flags().GetString(flags.SecretAccessKeyAcmPca)
 		sessionToken, _ := cmd.Flags().GetString(flags.SessionTokenAcmPca)
 
 		err := argsValidationHandler.IsValidRevocationReason(revocationReason)
@@ -31,8 +35,9 @@ var revokeCertificateCmd = &cobra.Command{
 			return
 		}
 
-		creds := awsService.NewAwsCredentialsObject(accessKey, secretAccessKey, sessionToken, profileName)
-		_, err = acmpcaService.RevokeCertificate(creds, certArn, pcaArn, revocationReason, region)
+		acmCreds := awsService.NewAwsCredentialsObject(acmAccessKey, acmSecretAccessKey, sessionToken, profileNameAcm)
+		acmPcaCreds := awsService.NewAwsCredentialsObject(acmPcaAccessKey, acmPcaSecretAccessKey, sessionToken, profileNameAcmPca)
+		_, err = acmpcaService.RevokeCertificate(acmCreds, acmPcaCreds, certArn, pcaArn, revocationReason, acmRegion, pcaRegion)
 		cobra.CheckErr(err)
 
 	},
@@ -42,11 +47,15 @@ func init() {
 	rootCmd.AddCommand(revokeCertificateCmd)
 
 	revokeCertificateCmd.PersistentFlags().String(flags.PcaRegion, "eu-east-1", flags.RegionNameAcmPcaDesc)
-	revokeCertificateCmd.PersistentFlags().String(flags.ProfileName, "default", flags.ProfNameAcmPcaDesc)
+	revokeCertificateCmd.PersistentFlags().String(flags.AcmRegion, "eu-east-1", flags.RegionNameAcmDesc)
+	revokeCertificateCmd.PersistentFlags().String(flags.ProfileNameAcmPca, "default", flags.ProfNameAcmPcaDesc)
+	revokeCertificateCmd.PersistentFlags().String(flags.ProfileNameAcm, "default", flags.ProfNameAcmDesc)
 	revokeCertificateCmd.PersistentFlags().String(flags.AccessKeyAcmPca, "", flags.AccessKeyAcmPcaDesc)
+	revokeCertificateCmd.PersistentFlags().String(flags.AccessKeyAcm, "", flags.AccessKeyAcmDesc)
 	revokeCertificateCmd.PersistentFlags().String(flags.SecretAccessKeyAcmPca, "", flags.SecretAccessKeyAcmPcaDesc)
+	revokeCertificateCmd.PersistentFlags().String(flags.SecretAccessKeyAcm, "", flags.SecretAccessKeyAcmDesc)
 	revokeCertificateCmd.PersistentFlags().String(flags.SessionTokenAcmPca, "", flags.SessionTokenAcmPcaDesc)
-
+	revokeCertificateCmd.PersistentFlags().String(flags.SessionTokenAcm, "", flags.SessionTokenAcmDesc)
 	revokeCertificateCmd.PersistentFlags().StringP(flags.CertificateArn, "c", "", flags.CertArnDesc)
 	revokeCertificateCmd.PersistentFlags().StringP(flags.AcmpcaArn, "a", "", flags.AcmPcaArnDesc)
 	revokeCertificateCmd.PersistentFlags().StringP(flags.RevocationReason, "r", revocationReasons.Unspecified, flags.RevocReasonDesc)

--- a/src/cmd/rotate-certificate.go
+++ b/src/cmd/rotate-certificate.go
@@ -42,16 +42,16 @@ var rotateCertificateCmd = &cobra.Command{
 
 		_, err := acmpcaService.GenerateCertificate(acmPcaCreds, acmpcaArn, commonName, organizationName, organizationalUnit, country, locality, province, certificateDirectory, pcaRegion, expiryDays)
 		cobra.CheckErr(err)
-		_, err = acmService.ImportCertificate(acmCreds, certificateDirectory, acmRegion)
+		_, err = acmService.ImportCertificate(acmCreds, certificateDirectory, acmRegion) // To JS - Should this be using default profile?
 		cobra.CheckErr(err)
-		_, err = acmpcaService.RevokeCertificate(acmPcaCreds, certArn, acmpcaArn, revocationReasons.Superseded, pcaRegion)
+		_, err = acmpcaService.RevokeCertificate(acmCreds, acmPcaCreds, certArn, acmpcaArn, revocationReasons.Superseded, acmRegion, pcaRegion)
 		cobra.CheckErr(err)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(rotateCertificateCmd)
-	
+
 	rotateCertificateCmd.PersistentFlags().String(flags.ProfileNameAcm, "default", flags.ProfNameAcmDesc)
 	rotateCertificateCmd.PersistentFlags().String(flags.ProfileNameAcmPca, "default", flags.ProfNameAcmPcaDesc)
 	rotateCertificateCmd.PersistentFlags().String(flags.AcmRegion, "eu-east-1", flags.RegionNameAcmDesc)

--- a/src/credentialService/credentialService.go
+++ b/src/credentialService/credentialService.go
@@ -78,11 +78,24 @@ func CreateCredentialsFile(filePath string) (*os.File, error) {
 	return os.Create(filePath)
 }
 
+func GetIniFile() *ini.File {
+	cfg, err := ini.Load(CredentialsFilePath)
+	Check(err)
+	return cfg
+}
+
 func WriteIniFile(template *CredentialsFileTemplate, profile string) {
 	cfg, err := ini.Load(CredentialsFilePath)
 	Check(err)
 	RecreateSection(template, profile, cfg)
 	cfg.SaveTo(CredentialsFilePath)
+}
+
+func LoadSection(profile string) *ini.Section {
+	cfg, err := ini.Load(CredentialsFilePath)
+	Check(err)
+	section := cfg.Section(profile)
+	return section
 }
 
 func RecreateSection(template *CredentialsFileTemplate, profile string, cfg *ini.File) {


### PR DESCRIPTION
This PR fixes the issue of the AWS SDK overwriting the [default] section of the AWS credentials file. Note that it is always "default" that is overwritten, despite using other profiles, hence the hardcoding of the "default" profile name.